### PR TITLE
fix(app/bananas): update bootstrap to fetch opengfx2

### DIFF
--- a/app/bananas/server.py
+++ b/app/bananas/server.py
@@ -57,8 +57,8 @@ class Server(pulumi.ComponentResource):
         cdn_fallback_url = pulumi.Output.format("https://{}-cdn.{}", args.hostname, args.domain)
         sentry_key = pulumi_openttd.get_sentry_key("bananas-server", args.sentry_ingest_hostname, args.domain)
 
-        # Make sure the bootstrap request returns OpenGFX.
-        boostrap_command = '"--bootstrap-unique-id", "4f474658",'
+        # Make sure the bootstrap request returns OpenGFX2.
+        boostrap_command = '"--bootstrap-unique-id", "6f676678",'
 
         SETTINGS = {
             "bootstrap_command": boostrap_command,


### PR DESCRIPTION
Set up OpenGFX2 as the new default base graphics set. [As per discussions](https://github.com/OpenTTD/OpenTTD/issues/13747), update the bootstrap command to return the unique ID of [OpenGFX2 ](https://bananas.openttd.org/manager/base-graphics/6f676678) on BaNaNaS instead of OpenGFX.