### PR TITLE
change: use opengfx2_classic instead of opengfx for bootstrap

### DIFF
--- a/app/bananas/server.py
+++ b/app/bananas/server.py
@@ -57,8 +57,8 @@ class Server(pulumi.ComponentResource):
         cdn_fallback_url = pulumi.Output.format("https://{}-cdn.{}", args.hostname, args.domain)
         sentry_key = pulumi_openttd.get_sentry_key("bananas-server", args.sentry_ingest_hostname, args.domain)
 
-        # Make sure the bootstrap request returns OpenGFX.
-        boostrap_command = '"--bootstrap-unique-id", "4f474658",'
+        # Make sure the bootstrap request returns OpenGFX2_classic.
+        boostrap_command = '"--bootstrap-unique-id", "6f676678",'
 
         SETTINGS = {
             "bootstrap_command": boostrap_command,


### PR DESCRIPTION
As per https://github.com/OpenTTD/OpenTTD/issues/13747 we'd like OpenGFX2 to be the default base graphics.

Change ID for bootstrapping to OpenGFX2 classic (see https://bananas.openttd.org/package/base-graphics).